### PR TITLE
Add test for SIG_CHLD handler in spawned process

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -578,4 +578,18 @@ subtest 'process in process' => sub {
     is ($p->read_all_stdout(), 'DONE', "Use ReadWriteProcess inside of ReadWriteProcess(code=>'')");
 };
 
+subtest 'SIG_CHLD handler in spawned process' => sub {
+  my $simple_rwp = "$FindBin::Bin/data/simple_rwp.pl";
+  my $sigchld_handler = "$FindBin::Bin/data/sigchld_handler.pl";
+
+  # use `perl <script>` here, as Github ci action place the used perl executable
+  # somewhere like /opt/hostedtoolcache/perl/<version>/<arch>/bin/perl so
+  # /usr/bin/perl wouldn't have all needed dependencies
+  is( process(execute => 'perl')->args([$simple_rwp])->start()->wait_stop()->exit_status(), 0, 'simple_rwp.pl exit with 0');
+
+  my $p = process(execute => $sigchld_handler);
+  is( $p->start()->wait_stop()->exit_status(), 0, 'sigchld_handler.pl exit with 0');
+  like( $p->read_all_stdout, qr/SIG_CHLD/, "SIG_CHLD handler was executed");
+};
+
 done_testing;

--- a/t/data/sigchld_handler.pl
+++ b/t/data/sigchld_handler.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+use Time::HiRes 'sleep';
+
+my $collected_pid = -1;
+$SIG{CHLD} = sub {
+    $collected_pid = waitpid(-1, 0);
+    print "SIG_CHLD $collected_pid exit:" . ( $?>>8) . "\n";
+};
+
+my $pid = fork();
+if ($pid == 0) {
+  print "I'm the child $$\n";
+  exit 0;
+}
+print "Forked child is $pid\n";
+sleep 0.1 while($collected_pid != $pid);
+print "Exit graceful\n";
+exit 0;

--- a/t/data/simple_rwp.pl
+++ b/t/data/simple_rwp.pl
@@ -1,0 +1,6 @@
+#!/usr/bin/perl
+use FindBin;
+use lib ("$FindBin::Bin/../../lib");
+use Mojo::IOLoop::ReadWriteProcess 'process';
+
+exit process(execute => '/usr/bin/true')->start()->wait_stop()->exit_status();


### PR DESCRIPTION
During discussion of https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/issues/29
we realized that a tests like this need to be successful.

The reason for it is, if we use `session::protect()` when doing the
`fork()` or `open3()` then the sigmask of the child still has SIGCHLD
blocked.
