### PR TITLE
Checking in changes prior to tagging of version 0.32.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -24,7 +24,7 @@ my %args = (
 
     requires => {
         'IPC::SharedMem' => '0',
-        'Mojolicious' => '7.24',
+        'Mojolicious' => '0',
     },
 
     recommends => {
@@ -37,7 +37,8 @@ my %args = (
     },
 
     test_requires => {
-        'Test::More' => '0.98',
+        'Test::Exception' => '0',
+        'Test::More' => '0',
     },
 
     name            => 'Mojo-IOLoop-ReadWriteProcess',

--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ Revision history for Perl extension Mojo-IOLoop-ReadWriteProcess
 
 {{$NEXT}}
 
+0.32 2021-12-09T18:03:02Z
+ - Project moved to https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess
+ - Introduce emit_from_sigchld()
+ - CI moved to GitHub Actions 
+
+
 0.31 2021-12-01T15:51:06Z
  - Fix bad release to cpan
  - Enable GitHub Actions for the project

--- a/META.json
+++ b/META.json
@@ -34,27 +34,42 @@
       },
       "develop" : {
          "requires" : {
+            "Devel::Cover" : "0",
+            "Devel::Cover::Report::Codecovbash" : "0",
             "Test::CPAN::Meta" : "0",
             "Test::MinimumVersion::Fast" : "0.04",
             "Test::PAUSE::Permissions" : "0.07",
             "Test::Pod" : "1.41",
+            "Test::Pod::Coverage" : "0",
             "Test::Spellunker" : "v0.2.7"
          }
       },
       "runtime" : {
          "requires" : {
             "IPC::SharedMem" : "0",
-            "Mojolicious" : "7.24"
+            "Mojolicious" : "0"
          }
       },
       "test" : {
          "requires" : {
-            "Test::More" : "0.98"
+            "Test::Exception" : "0",
+            "Test::More" : "0"
          }
       }
    },
    "release_status" : "unstable",
-   "version" : "0.31",
+   "resources" : {
+      "bugtracker" : {
+         "web" : "https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess/issues"
+      },
+      "homepage" : "https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess",
+      "repository" : {
+         "type" : "git",
+         "url" : "git://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess.git",
+         "web" : "https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess"
+      }
+   },
+   "version" : "0.32",
    "x_contributors" : [
       "Adam Williamson <awilliam@redhat.com>",
       "Clemens Famulla-Conrad <cfamullaconrad@suse.de>",
@@ -66,7 +81,8 @@
       "Santiago Zarate <229240+foursixnine@users.noreply.github.com>",
       "Santiago Zarate <santiago+github@zarate.co>",
       "Santiago Zarate <santiago@zarate.co>",
-      "Sebastian Riedel <sri@cpan.org>"
+      "Sebastian Riedel <sri@cpan.org>",
+      "cfconrad <40127946+cfconrad@users.noreply.github.com>"
    ],
    "x_serialization_backend" : "JSON::PP version 4.06",
    "x_static_install" : 0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Coverage Status](http://codecov.io/github/openSUSE/Mojo-IOLoop-ReadWriteProcess/coverage.svg?branch=master)](https://codecov.io/github/openSUSE/Mojo-IOLoop-ReadWriteProcess?branch=master)[![linux](https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess/actions/workflows/ci-linux.yaml/badge.svg)](https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess/actions/workflows/ci-linux.yaml)
-
+[![Coverage Status](http://codecov.io/github/openSUSE/Mojo-IOLoop-ReadWriteProcess/coverage.svg?branch=master)](https://codecov.io/github/openSUSE/Mojo-IOLoop-ReadWriteProcess?branch=master) [![Actions Status](https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess/workflows/linux/badge.svg)](https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess/actions)
 # NAME
 
 Mojo::IOLoop::ReadWriteProcess - Execute external programs or internal code blocks as separate process.

--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -1,6 +1,6 @@
 package Mojo::IOLoop::ReadWriteProcess;
 
-our $VERSION = '0.31';
+our $VERSION = '0.32';
 
 use Mojo::Base 'Mojo::EventEmitter';
 use Mojo::File 'path';

--- a/minil.toml
+++ b/minil.toml
@@ -4,3 +4,6 @@ module_maker="ModuleBuild"
 
 [build]
 build_class = "builder::custom"
+
+[Metadata.resources]
+repository = "https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess"


### PR DESCRIPTION
Changelog diff is:

diff --git a/Changes b/Changes
index 3650797..b4e138f 100644
--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ Revision history for Perl extension Mojo-IOLoop-ReadWriteProcess
 
 {{$NEXT}}
 
+0.32 2021-12-09T18:03:02Z
+ - Project moved to https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess
+ - Introduce emit_from_sigchld()
+ - CI moved to GitHub Actions 
+
+
 0.31 2021-12-01T15:51:06Z
  - Fix bad release to cpan
  - Enable GitHub Actions for the project