### PR TITLE
Fix sporadic 01_run.t failure -- "process is still running"

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -223,6 +223,7 @@ subtest 'process execute()' => sub {
     max_kill_attempts     => -4,
   );    # ;)
   $p->start();
+  is($p->read_stdout(), "term_trap.sh started\n");
   $p->stop();
   is $p->is_running, 1,     'process is still running';
   is $p->_status,    undef, 'no status yet';
@@ -613,17 +614,23 @@ subtest 'execute exeption handling' => sub {
 };
 
 subtest 'SIG_CHLD handler in spawned process' => sub {
-  my $simple_rwp = "$FindBin::Bin/data/simple_rwp.pl";
+  my $simple_rwp      = "$FindBin::Bin/data/simple_rwp.pl";
   my $sigchld_handler = "$FindBin::Bin/data/sigchld_handler.pl";
 
   # use `perl <script>` here, as Github ci action place the used perl executable
   # somewhere like /opt/hostedtoolcache/perl/<version>/<arch>/bin/perl so
   # /usr/bin/perl wouldn't have all needed dependencies
-  is( process(execute => 'perl')->args([$simple_rwp])->start()->wait_stop()->exit_status(), 0, 'simple_rwp.pl exit with 0');
+  is(
+    process(execute => 'perl')->args([$simple_rwp])->start()->wait_stop()
+      ->exit_status(),
+    0,
+    'simple_rwp.pl exit with 0'
+  );
 
   my $p = process(execute => $sigchld_handler);
-  is( $p->start()->wait_stop()->exit_status(), 0, 'sigchld_handler.pl exit with 0');
-  like( $p->read_all_stdout, qr/SIG_CHLD/, "SIG_CHLD handler was executed");
+  is($p->start()->wait_stop()->exit_status(),
+    0, 'sigchld_handler.pl exit with 0');
+  like($p->read_all_stdout, qr/SIG_CHLD/, "SIG_CHLD handler was executed");
 };
 
 done_testing;

--- a/t/data/sigchld_handler.pl
+++ b/t/data/sigchld_handler.pl
@@ -5,8 +5,8 @@ use Time::HiRes 'sleep';
 
 my $collected_pid = -1;
 $SIG{CHLD} = sub {
-    $collected_pid = waitpid(-1, 0);
-    print "SIG_CHLD $collected_pid exit:" . ( $?>>8) . "\n";
+  $collected_pid = waitpid(-1, 0);
+  print "SIG_CHLD $collected_pid exit:" . ($? >> 8) . "\n";
 };
 
 my $pid = fork();
@@ -15,6 +15,6 @@ if ($pid == 0) {
   exit 0;
 }
 print "Forked child is $pid\n";
-sleep 0.1 while($collected_pid != $pid);
+sleep 0.1 while ($collected_pid != $pid);
 print "Exit graceful\n";
 exit 0;

--- a/t/data/term_trap.sh
+++ b/t/data/term_trap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-(sleep 25; echo "Hello World") &
 trap "echo I ALWAYS WIN" SIGINT SIGTERM
+echo "term_trap.sh started"
+(sleep 25; echo "Hello World") &
 echo "pid is $$"
 
 while :


### PR DESCRIPTION
We encountered flaky 01_run.t tests with the error looks like:
```
 #   Failed test 'process is still running'
 #   at t/01_run.t line 235.
 #          got: '0'
 #     expected: '1'
 # Looks like you failed 1 test of 38.

 #   Failed test 'process execute()'
 #   at t/01_run.t line 302.
```
It occurs in one out of ~300 runs. This fix assume, that we actually
send the SIGTERM before the executed script `term_trap.sh` has setup
it's traphandler to ignore such signal.

The fix just listen on STDOUT of the script to get informed, once the
sighandlers are setted and then continue.

A sleep would be ok as well, but it's harder to judge how long is a good
sleep :).