### PR TITLE
remove hard-coding of OABI syscall entry point

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
@@ -175,7 +175,6 @@ sub _get_prctl_syscall {
     : ($machine eq "ppc" || $machine eq "ppc64le") ? 171
     : $machine eq "ia64"                           ? 1170
     : $machine eq "alpha"                          ? 348
-    : ($machine eq "arm" || $machine eq "armv7l")  ? 0x900000 + 172
     : $machine eq "avr32"                          ? 148
     : $machine eq "mips"                           ? 4000 + 192
     : $machine eq "mips64"                         ? 5000 + 153


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Mojo-IOLoop-ReadWriteProcess.
We thought you might be interested in it too.

    Description: remove hard-coding of OABI syscall entry point
     Package fails autopkgtests on armhf in Ubuntu because the kernel doesn't
     expose the OABI syscall personality, and this code pointlessly hardcodes
     a syscall number for the platform instead of using the system definition.
    Bug-Debian: https://bugs.debian.org/1025824
    Author: Steve Langasek <steve.langasek@ubuntu.com>
    Reviewed-by: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-12-11
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libmojo-ioloop-readwriteprocess-perl/raw/master/debian/patches/wrong-arm-syscall-use.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
