### PR TITLE
Revert "Enable support for MacOSX (darwin)"

### DIFF
--- a/builder/custom.pm
+++ b/builder/custom.pm
@@ -4,10 +4,11 @@ use warnings;
 use warnings FATAL => qw(recursion);
 use parent qw(Module::Build);
 
+
 sub new {
   my ($class, %args) = @_;
-  die "OS Unsupported: " . $^O if ($^O !~ m#(?i)(Linux|darwin)#);
-  print $^O;
+  die "OS Unsupported" if ($^O !~ m#(?i)Linux#);
   return $class->SUPER::new(%args);
 }
+
 1;

--- a/t/11_containers.t
+++ b/t/11_containers.t
@@ -14,15 +14,12 @@ use Mojo::IOLoop::ReadWriteProcess::CGroup      qw(cgroupv2 cgroupv1);
 use Mojo::IOLoop::ReadWriteProcess::Container   qw(container);
 
 eval {
-  die "OS Unsupported: " . $^O if ($^O !~ m#(?i)(Linux)#);
   my $try_cgroup
     = cgroupv1(controller => 'pids', name => 'group')->child('test')->create;
   die unless $try_cgroup->exists();
 };
 
-plan skip_all =>
-  "This test works only if you have cgroups permissions or a supported OS"
-  if $@;
+plan skip_all => "This test works only if you have cgroups permissions" if $@;
 
 subtest belongs => sub {
   cgroupv1(controller => 'pids', name => 'group')->create;

--- a/t/12_mocked_container.t
+++ b/t/12_mocked_container.t
@@ -17,17 +17,6 @@ use Mojo::IOLoop::ReadWriteProcess::Container   qw(container);
 use Mojo::Util 'monkey_patch';
 use Mojo::IOLoop::ReadWriteProcess::Namespace;
 
-eval {
-  die "OS Unsupported: " . $^O if ($^O !~ m#(?i)(Linux)#);
-  my $try_cgroup
-    = cgroupv1(controller => 'pids', name => 'group')->child('test')->create;
-  die unless $try_cgroup->exists();
-};
-
-plan skip_all =>
-  "This test works only if you have cgroups permissions or a supported OS"
-  if $@;
-
 sub mock_test {
   my $c = shift;
   my @pids;

--- a/t/data/simple_rwp.pl
+++ b/t/data/simple_rwp.pl
@@ -3,7 +3,4 @@ use FindBin;
 use lib ("$FindBin::Bin/../../lib");
 use Mojo::IOLoop::ReadWriteProcess 'process';
 
-# Not all systems have /bin/true, this is /usr/bin/true on osx for instance
-my $p
-  = process(execute => 'command -v true')->start()->wait_stop->read_all_stdout;
-exit process(execute => $p)->start()->wait_stop()->exit_status();
+exit process(execute => '/bin/true')->start()->wait_stop()->exit_status();


### PR DESCRIPTION
Seems force push was still allowed

This reverts commit fea0105cd5c36657e10886d7e4ebdcde15514db9.
