### PR TITLE
Fix handling process groups when initial process is not running anymore

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -403,7 +403,8 @@ sub restart {
 sub is_running {
   my ($self) = shift;
   $self->session->consume_collected_info;
-  $self->process_id ? kill 0 => $self->process_id : 0;
+  return 0 unless my $pid = $self->process_id;
+  kill(0, ($self->kill_whole_group ? -$pid : $pid));
 }
 
 sub write_pidfile {
@@ -519,7 +520,6 @@ sub stop {
   my $pid = $self->pid;
   return $self               unless defined $pid;
   return $self->_shutdown(1) unless $self->is_running;
-  $self->_diag("Stopping $pid") if DEBUG;
 
   my $ret;
   my $attempt      = 1;
@@ -527,7 +527,9 @@ sub stop {
   my $sleep_time   = $self->sleeptime_during_kill;
   my $max_attempts = $self->max_kill_attempts;
   my $signal       = $self->_default_kill_signal;
-  $pid = -getpgrp($pid) if $self->kill_whole_group;
+  $pid = -$pid if $self->kill_whole_group;
+  $self->_diag("Stopping $pid") if DEBUG;
+
   until ((defined $ret && ($ret == $pid || $ret == -1))
       || ($attempt > $max_attempts && $timeout <= 0))
   {


### PR DESCRIPTION
One can set the `kill_whole_group` attribute to make the `stop` function of `ReadWriteProcess` stop the whole process group. This works in general but there are a few flaws this change addresses:

* Make `is_running` consider the whole process group as well. Otherwise, when the initial process is not running anymore `stop` returns early, even though there are still other processes left in the group.
* Avoid the use of `getpgrp` in the `stop` function. This function needs the PID to be still valid but this might not be the case when the initial process is not running anymore. The group ID is simply the PID of the initial process so we can just use that. (Assuming the the process group was created by invoking `setpgrp(0, 0)` in the code callback.)

I tested this by creating a simple script that will leave a leftover process¹. In the code callback I executed `setpgrp(0, 0)` followed by `exec(…)` on that script. Without this change the a process is left behind when calling `stop` (see `ps -aux | grep 'sleep infinity'`). With this change the process is correctly cleaned up. I used existing code of openQA (`isotovideo.pm`) to test this.

Related issue: https://progress.opensuse.org/issues/170209

---

¹
```
#!/bin/bash
sleep infinity &
```