### PR TITLE
Fix race condition in `is_running` when `kill_whole_group` is set

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -404,7 +404,7 @@ sub is_running {
   my ($self) = shift;
   $self->session->consume_collected_info;
   return 0 unless my $pid = $self->process_id;
-  kill(0, ($self->kill_whole_group ? -$pid : $pid));
+  kill(0, ($self->kill_whole_group ? (-$pid, $pid) : ($pid)));
 }
 
 sub write_pidfile {


### PR DESCRIPTION
This fixes a bug introduced in ba7bb38 leading to `isotovideo can not be started` in openQA.

We must not *only* check the process group because it might not have been created. (The `is_running` function might be called immediately after `start` when `setpgrp(0, 0)` hasn't been executed yet.)

I tested this by putting `sleep 5` before `setpgrp(0, 0)`. Without this change openQA runs into `isotovideo can not be started` and with this change it works. I also tested whether cleanup of the whole process gorup still works.

Related ticket: https://progress.opensuse.org/issues/170209