### PR TITLE
Fix sporadic failures in `t/01_run.t`

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -498,6 +498,8 @@ subtest stop_whole_process_group_gracefully => sub {
   my $test_gpid       = getpgrp(0);
   my $sub_process_pid = $sub_process->pid;
   sleep 0.1 while $test_gpid == getpgrp($sub_process_pid);
+  note "test pid: $$, gpid: $test_gpid";
+  note "sub process pid: $sub_process_pid, gpid: " . getpgrp($sub_process_pid);
 
   $sub_process->stop();
   is $sub_process->is_running, 0, 'process is shut down via kill_whole_group';

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -467,6 +467,10 @@ subtest 'process code()' => sub {
   is $p->read_all, '', 'stdout is empty';
 };
 
+sub _number_of_process_in_group {
+  scalar(split "\n", qx{pgrep -g @_} or die "Unable to run pgrep: $!");
+}
+
 subtest stop_whole_process_group_gracefully => sub {
   my $test_script = check_bin("$FindBin::Bin/data/simple_fork.pl");
 
@@ -497,9 +501,13 @@ subtest stop_whole_process_group_gracefully => sub {
   #       stop would also stop the test itself.
   my $test_gpid       = getpgrp(0);
   my $sub_process_pid = $sub_process->pid;
-  sleep 0.1 while $test_gpid == getpgrp($sub_process_pid);
+  my $sub_process_gid;
+  note 'waiting until process group has been created';
+  sleep 0.01 while $test_gpid == ($sub_process_gid = getpgrp($sub_process_pid));
   note "test pid: $$, gpid: $test_gpid";
-  note "sub process pid: $sub_process_pid, gpid: " . getpgrp($sub_process_pid);
+  note "sub process pid: $sub_process_pid, gpid: $sub_process_gid";
+  note 'waiting until all sub processes have been forked';
+  sleep 0.01 until _number_of_process_in_group($sub_process_gid) == 3;
 
   $sub_process->stop();
   is $sub_process->is_running, 0, 'process is shut down via kill_whole_group';


### PR DESCRIPTION
Wait until all sub processes have been forked before stopping the main sub process. This may help to avoid sporatic failure we sometimes see on OBS on ppc64le and aarch64 builds (probably because those machines tend to be slow).

Related ticket: https://progress.opensuse.org/issues/178183

---

This seems to help, see https://build.opensuse.org/package/show/home:mkittler:branches:devel:languages:perl/perl-Mojo-IOLoop-ReadWriteProcess. Of course this doesn't mean that much because the issue isn't always reproducible.

That will require `pgrep` to be installed in the test environment. The env for CI checks is currently broken anyway, though.