### PR TITLE
Update condition for process list definitions in 12_mocked_container

### DIFF
--- a/t/12_mocked_container.t
+++ b/t/12_mocked_container.t
@@ -40,7 +40,7 @@ sub mock_test {
 
   attempt {
     attempts  => 20,
-    condition => sub { defined $cgroups->first->process_list },
+    condition => sub { $cgroups->first->process_list // '' =~ /\d+/ },
     cb        => sub { sleep 1; }
   };
 


### PR DESCRIPTION
define return true even if the variable is empty, with this change the attempt continue to run unless the process_list contain some pid

related: https://progress.opensuse.org/issues/178186