### PR TITLE
CI: Update+fix+simplify

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: codecov/codecov-action@v4
         if: matrix.perl == 'latest'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: cover_db/codecov.json
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           TEST_SHARED=1 TEST_SUBREAPER=1 cover -test -report codecovbash
       - name: Upload coverage to ☂️ Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: matrix.perl == 'latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -7,14 +7,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         perl:
-            - '5.16'
-            - '5.20'
-            - '5.26'
-            - '5.30'
-            - '5.34'
-            - '5.38'
-            - '5.40'
-            - latest
+          - '5.16'
+          - '5.20'
+          - '5.26'
+          - '5.30'
+          - '5.34'
+          - '5.38'
+          - '5.40'
+          - latest
         include:
           - os: macos-latest
             perl: '5.26'

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -25,7 +25,7 @@ jobs:
             perl: latest
     name: 🐪 Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl }}

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -38,7 +38,7 @@ jobs:
           TEST_SHARED=1 TEST_SUBREAPER=1 cover -test -report codecovbash
       - name: Upload coverage to ☂️ Codecov
         uses: codecov/codecov-action@v3
-        if: matrix.perl == '5.40'
+        if: matrix.perl == 'latest'
         with:
           file: cover_db/codecov.json
           fail_ci_if_error: true

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           TEST_SHARED=1 TEST_SUBREAPER=1 cover -test -report codecovbash
       - name: Upload coverage to ☂️ Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: matrix.perl == 'latest'
         with:
           file: cover_db/codecov.json

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,11 +1,5 @@
 name: Unit and integration tests
-on:
-  push:
-    branches:
-      - '*'
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -17,6 +17,9 @@ jobs:
             - '5.20'
             - '5.26'
             - '5.30'
+            - '5.34'
+            - '5.38'
+            - '5.40'
             - latest
         include:
           - os: macos-latest
@@ -41,7 +44,7 @@ jobs:
           TEST_SHARED=1 TEST_SUBREAPER=1 cover -test -report codecovbash
       - name: Upload coverage to ☂️ Codecov
         uses: codecov/codecov-action@v3
-        if: matrix.perl == '5.30'
+        if: matrix.perl == '5.40'
         with:
           file: cover_db/codecov.json
           fail_ci_if_error: true

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -33,7 +33,7 @@ jobs:
           cpanm --with-feature=ci --installdeps --notest .
           perl Build.PL
           ./Build build
-      - name: Run tests 
+      - name: Run tests
         run: |
           TEST_SHARED=1 TEST_SUBREAPER=1 cover -test -report codecovbash
       - name: Upload coverage to ☂️ Codecov


### PR DESCRIPTION
* CI: Bump to codecov-action@v5
* CI: Use codecov token to prevent rate limit
* CI: Bump to codecov-action@v4
* CI: Fix indendation in version matrix
* CI: Simply use version 'latest' for codecov upload
* CI: Remove trailing space in title
* CI: Simplify 'on' definition
* CI: Add recent and current Perl versions
* CI: Use current version of checkout@v4

https://progress.opensuse.org/issues/176148