### PR TITLE
Prepare release of 1.0.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,14 @@
 Revision history for Perl extension Mojo-IOLoop-ReadWriteProcess
 
 {{$NEXT}}
+1.0.0 2025-03-17 12:20:20Z
+ -  Various test fixes
+ -  Fix race condition in `is_running` when `kill_whole_group` is set
+ -  Fix handling process groups when initial process is not running anymore
+ -  Add Minilla to the ci target
+ -  Update minil.toml to have the harness arguments enabled
+ -  Mention syntactic sugar to help when debugging
+ -  Enable support for MacOSX (darwin)
 
 0.34 2023-09-18T15:47:18Z
  - Adapt to deprecation of spurt in upstream Mojolicious

--- a/META.json
+++ b/META.json
@@ -69,7 +69,7 @@
          "web" : "https://github.com/openSUSE/Mojo-IOLoop-ReadWriteProcess"
       }
    },
-   "version" : "0.34",
+   "version" : "1.0.0",
    "x_contributors" : [
       "Adam Williamson <awilliam@redhat.com>",
       "Clemens Famulla-Conrad <cfamullaconrad@suse.de>",

--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -1,6 +1,6 @@
 package Mojo::IOLoop::ReadWriteProcess;
 
-our $VERSION = '0.34';
+our $VERSION = '1.0.0';
 
 use Mojo::Base 'Mojo::EventEmitter';
 use Mojo::File 'path';


### PR DESCRIPTION
Use semver.org compatible version format and jump to 1.0.0 to avoid any
version computing ambiguities.

As per
https://github.com/semver/semver.org/issues/1 and
https://semver.org/#is-v123-a-semantic-version the version number itself
does not include a "v"-prefix itself however the prefix can be included
in denoting a version string.

References:
* https://semver.org/
* https://blogs.perl.org/users/grinnz/2018/04/a-guide-to-versions-in-perl.html
* https://github.com/perlpunk/perl5-module-meta
* https://github.com/semver/semver.org/issues/1