### PR TITLE
t: Skip if pgrep is not installed

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -475,6 +475,7 @@ sub _number_of_process_in_group {
 }
 
 subtest stop_whole_process_group_gracefully => sub {
+  check_bin('/usr/bin/pgrep');
   my $test_script = check_bin("$FindBin::Bin/data/simple_fork.pl");
 
   # run the "term_trap.pl" script and its sub processes within its own


### PR DESCRIPTION
Otherwise the test might fail, and sometimes we don't even see an error message with the reason, like observed in OBS or probably here on cpantesters:
http://www.cpantesters.org/cpan/report/47446f5e-103b-11f0-98b0-b3c3213a625c http://www.cpantesters.org/cpan/report/57cba9ba-1017-11f0-98b0-b3c3213a625c