### PR TITLE
Bump the all-actions group across 1 directory with 2 updates

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -22,7 +22,7 @@ jobs:
             perl: latest
     name: 🐪 Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6  # v1
         with:
           perl-version: ${{ matrix.perl }}
@@ -49,7 +49,7 @@ jobs:
           ./retry -r 7 env TEST_SHARED=1 TEST_SUBREAPER=1 PERL5OPT="-MDevel::Cover=-coverage,statement" prove -l t
           cover -report codecovbash
       - name: Upload coverage to ☂️ Codecov
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         if: matrix.perl == 'latest' && matrix.os != 'macos-latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/perltidy.yml
+++ b/.github/workflows/perltidy.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: perl:5.40
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: perl -V
         run: perl -V
       - name: Install dependencies

--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -180,7 +180,7 @@ sub _fork_collect_status {
       ? $self->_internal_return
       : $self->_internal_return->reader();
     $self->_new_err('Cannot read from return code pipe') && return
-      unless IO::Select->new($return_reader)->can_read(10);
+      unless _can_read($return_reader, 10);
     $rt = $return_reader->getline();
     $self->_diag("Forked code Process Returns: " . ($rt ? $rt : 'nothing'))
       if DEBUG;
@@ -195,7 +195,7 @@ sub _fork_collect_status {
       ? $self->_internal_err
       : $self->_internal_err->reader();
     $self->_new_err('Cannot read from errors code pipe') && return
-      unless IO::Select->new($internal_err_reader)->can_read(10);
+      unless _can_read($internal_err_reader, 10);
     @result_error = $internal_err_reader->getlines();
     push(
       @{$self->error},
@@ -424,13 +424,21 @@ sub _syswrite {
   $stream->syswrite($_ . "\n") for @_;
 }
 
+sub _can_read {
+  my ($handle, $timeout) = @_;
+  my $select = IO::Select->new($handle);
+  my @ready;
+  1 while !(@ready = $select->can_read($timeout)) && $!{EINTR};
+  return !!@ready;
+}
+
 sub _getline {
-  return unless IO::Select->new($_[0])->can_read(45);
+  return unless _can_read($_[0], 45);
   shift->getline;
 }
 
 sub _getlines {
-  return unless IO::Select->new($_[0])->can_read(45);
+  return unless _can_read($_[0], 45);
   wantarray ? shift->getlines : join '', @{[shift->getlines]};
 }
 

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -418,10 +418,7 @@ subtest 'process code()' => sub {
     sleeptime_during_kill => $interval,
     separate_err          => 0,
     code                  => sub {
-      my ($self)        = shift;
-      my $parent_output = $self->channel_out;
-      my $parent_input  = $self->channel_in;
-
+      my ($self) = shift;
       print "TEST normal print\n";
       print STDERR "TEST error print\n";
       return "256";
@@ -710,6 +707,34 @@ subtest 'SIG_CHLD handler in spawned process' => sub {
     diag "err: " . $p->read_stderr;
   };
   like($p->read_all_stdout, qr/SIG_CHLD/, "SIG_CHLD handler was executed");
+};
+
+subtest '_can_read signal interruption and coverage' => sub {
+  pipe(my $read_handle, my $write_handle);
+  $write_handle->autoflush(1);
+
+  print $write_handle "foo\n";
+  ok Mojo::IOLoop::ReadWriteProcess::_can_read($read_handle, 1),
+    'readable handle returns true';
+
+  <$read_handle>;
+  ok !Mojo::IOLoop::ReadWriteProcess::_can_read($read_handle, 0.1),
+    'not readable handle returns false';
+
+  my $can_read_calls = 0;
+  no warnings 'redefine';
+  local *IO::Select::can_read = sub {
+    $can_read_calls++;
+    if ($can_read_calls == 1) {
+      $! = POSIX::EINTR;
+      return ();
+    }
+    return ($read_handle);
+  };
+
+  my $ready_eintr = Mojo::IOLoop::ReadWriteProcess::_can_read($read_handle, 1);
+  is $can_read_calls, 2, 'can_read was called twice';
+  ok $ready_eintr, '_can_read successfully retried on EINTR and returned true';
 };
 
 done_testing;


### PR DESCRIPTION
Bumps the all-actions group with 2 updates in the / directory: [actions/checkout](https://github.com/actions/checkout) and [codecov/codecov-action](https://github.com/codecov/codecov-action).


Updates `actions/checkout` from 4.3.1 to 7.0.0
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/34e114876b0b11c390a56381ad16ebd13914f8d5...9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)

Updates `codecov/codecov-action` from 5.5.5 to 7.0.0
- [Release notes](https://github.com/codecov/codecov-action/releases)
- [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/codecov/codecov-action/compare/0fb7174895f61a3b6b78fc075e0cd60383518dac...fb8b3582c8e4def4969c97caa2f19720cb33a72f)

---
updated-dependencies:
- dependency-name: actions/checkout
  dependency-version: 7.0.0
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: all-actions
- dependency-name: codecov/codecov-action
  dependency-version: 7.0.0
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: all-actions
...

Signed-off-by: dependabot[bot] <support@github.com>